### PR TITLE
Fixed build script when trying to compile after invoking VsDevCmd.bat…

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,7 +6,7 @@ where /Q cl.exe || (
   call "%VS2019INSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" amd64 || exit /b 1
 )
 
-if "%Platform%" neq "x64" (
+if "%Platform%" neq "x64" if "%VSCMD_ARG_TGT_ARCH%" neq "x64" (
   echo ERROR: please run this from MSVC x64 native tools command prompt, 32-bit target is not supported!
   exit /b 1
 )


### PR DESCRIPTION
… instead of vcvarsall.bat.

Calling “VsDevCmd.bat -arch=x64 -host_arch=x64” does not set the environment variable %Platform% unlike “vcvarsall.bat x64”.
%VSCMD_ARG_TGT_ARCH% is defined when invoking both batch files.