### PR TITLE
Validate Output Folder path

### DIFF
--- a/wcap_config.h
+++ b/wcap_config.h
@@ -530,6 +530,15 @@ static LRESULT CALLBACK Config__DialogProc(HWND Window, UINT Message, WPARAM WPa
 			C->ShortcutMonitor = GetWindowLongW(GetDlgItem(Window, ID_SHORTCUT_MONITOR), GWLP_USERDATA);
 			C->ShortcutWindow  = GetWindowLongW(GetDlgItem(Window, ID_SHORTCUT_WINDOW),  GWLP_USERDATA);
 			C->ShortcutRegion  = GetWindowLongW(GetDlgItem(Window, ID_SHORTCUT_REGION),  GWLP_USERDATA);
+			
+			if (GetFileAttributesW(C->OutputFolder) == INVALID_FILE_ATTRIBUTES)
+			{
+				MessageBoxW(Window, L"  Save unsuccessful - Output Folder not found.\n\n  Choose a valid folder.", WCAP_TITLE, MB_ICONEXCLAMATION);
+				// Simulate click of ... button (browse folder).
+				// Will be handled in this same window procedure.
+				SendMessageW(Window, WM_COMMAND, ID_OUTPUT_FOLDER + 1, 0);
+				return -1;
+			}
 
 			EndDialog(Window, TRUE);
 			return TRUE;
@@ -821,7 +830,7 @@ static void Config__DoDialogLayout(const Config__DialogLayout* Layout, BYTE* Dat
 
 			if (Item->Item & ITEM_FOLDER)
 			{
-				Data = Config__DoDialogItem(Data, "", ItemId, CONTROL_EDIT, WS_TABSTOP | WS_BORDER, X, Y, W - BUTTON_SMALL_WIDTH - PADDING + 2, ITEM_HEIGHT);
+				Data = Config__DoDialogItem(Data, "", ItemId, CONTROL_EDIT, WS_TABSTOP | WS_BORDER | ES_AUTOHSCROLL, X, Y, W - BUTTON_SMALL_WIDTH - PADDING + 2, ITEM_HEIGHT);
 				ItemCount++;
 				ItemId++;
 


### PR DESCRIPTION
### 1. In the Output Edit or the ini file, type a path that does not exist.

<img width="310" height="72" alt="image" src="https://github.com/user-attachments/assets/bb4c6616-0e1f-4e0f-84aa-a33078fc588b" />

### 2. Press OK. It gets saved to the ini file.

<img width="555" height="226" alt="image" src="https://github.com/user-attachments/assets/1f9bbea7-d9c6-4c8d-a40f-734a2105bcf3" />

### **3. Press hotkey to start wcap recording. The following error shows:**

<img width="305" height="200" alt="image" src="https://github.com/user-attachments/assets/fa6e1400-732f-4a67-8b6e-3c79c15cd952" />  


**Also the user can't type a longer path than the size of the Output Edit. If you select a folder with a long path in the dialog, the chars longer than the edit cannot be seen/accessed bc the edit box does not have ES_AUTOHSCROLL**

<img width="298" height="72" alt="image" src="https://github.com/user-attachments/assets/6ef494ef-01be-431b-81d7-38150338680a" />  


**My commit fixes these issues.**