### PR TITLE
Prevent integer overflow for ES_NUMBER edits

### DIFF
--- a/wcap_config.h
+++ b/wcap_config.h
@@ -349,6 +349,10 @@ static void Config__SetDialogValues(HWND Window, Config* C)
 	SetDlgItemInt(Window, ID_VIDEO_MAX_HEIGHT,    C->VideoMaxHeight,    FALSE);
 	SetDlgItemInt(Window, ID_VIDEO_MAX_FRAMERATE, C->VideoMaxFramerate, FALSE);
 	SetDlgItemInt(Window, ID_VIDEO_BITRATE,       C->VideoBitrate,      FALSE);
+	for (unsigned short ID = ID_VIDEO_MAX_WIDTH; ID <= ID_VIDEO_BITRATE; ID += 10)
+	{
+		SendDlgItemMessageW(Window, ID, EM_SETLIMITTEXT, (WPARAM)9, 0);
+	}
 
 	// audio
 	CheckDlgButton(Window, ID_AUDIO_CAPTURE, C->CaptureAudio);
@@ -383,6 +387,10 @@ static void Config__SetDialogValues(HWND Window, Config* C)
 	EnableWindow(GetDlgItem(Window, ID_GPU_ENCODER + 1),  C->HardwareEncoder);
 	EnableWindow(GetDlgItem(Window, ID_LIMIT_LENGTH + 1), C->EnableLimitLength);
 	EnableWindow(GetDlgItem(Window, ID_LIMIT_SIZE + 1),   C->EnableLimitSize);
+	for (unsigned short ID = ID_LIMIT_LENGTH + 1; ID <= ID_LIMIT_SIZE + 1; ID += 10)
+	{
+		SendDlgItemMessageW(Window, ID, EM_SETLIMITTEXT, (WPARAM)9, 0);
+	}
 
 	EnableWindow(GetDlgItem(Window, ID_MOUSE_CURSOR),              ScreenCapture_CanHideMouseCursor());
 	EnableWindow(GetDlgItem(Window, ID_SHOW_RECORDING_BORDER),     ScreenCapture_CanHideRecordingBorder());
@@ -571,12 +579,24 @@ static LRESULT CALLBACK Config__DialogProc(HWND Window, UINT Message, WPARAM WPa
 		}
 		else if (Control == ID_LIMIT_LENGTH && HIWORD(WParam) == BN_CLICKED)
 		{
-			EnableWindow(GetDlgItem(Window, ID_LIMIT_LENGTH + 1), (BOOL)SendDlgItemMessageW(Window, ID_LIMIT_LENGTH, BM_GETCHECK, 0, 0));
+			BOOL IsChecked = (BOOL)SendDlgItemMessageW(Window, ID_LIMIT_LENGTH, BM_GETCHECK, 0, 0);
+			HWND LimitLengthEdit = GetDlgItem(Window, ID_LIMIT_LENGTH + 1);
+			EnableWindow(LimitLengthEdit, IsChecked);
+			if (IsChecked)
+			{
+				SendMessageW(Window, WM_NEXTDLGCTL, (WPARAM)LimitLengthEdit, TRUE);
+			}
 			return TRUE;
 		}
 		else if (Control == ID_LIMIT_SIZE && HIWORD(WParam) == BN_CLICKED)
 		{
-			EnableWindow(GetDlgItem(Window, ID_LIMIT_SIZE + 1), (BOOL)SendDlgItemMessageW(Window, ID_LIMIT_SIZE, BM_GETCHECK, 0, 0));
+			BOOL IsChecked = (BOOL)SendDlgItemMessageW(Window, ID_LIMIT_SIZE, BM_GETCHECK, 0, 0);
+			HWND LimitSizeEdit = GetDlgItem(Window, ID_LIMIT_SIZE + 1);
+			EnableWindow(LimitSizeEdit, IsChecked);
+			if (IsChecked)
+			{
+				SendMessageW(Window, WM_NEXTDLGCTL, (WPARAM)LimitSizeEdit, TRUE);
+			}
 			return TRUE;
 		}
 		else if (Control == ID_OUTPUT_FOLDER + 1)


### PR DESCRIPTION
### 1. In the following edits type numbers that overflow 32 bit unsigned int.

<img width="277" height="142" alt="image" src="https://github.com/user-attachments/assets/4654b925-a7c4-4b8d-a28f-f3f71c031e41" />
<img width="301" height="77" alt="image" src="https://github.com/user-attachments/assets/1f3927ba-5b09-4fa8-b6d5-4a632cc6bad3" />

### 2. Click OK to save.

### 3. It overflows DWORD. Gets write to ini file as 0.

<img width="231" height="91" alt="image" src="https://github.com/user-attachments/assets/957ca091-d7a5-46f9-8c51-49cc908c7557" />
<img width="652" height="42" alt="image" src="https://github.com/user-attachments/assets/c750c2d9-c89a-4f09-b416-6ae06f8ae123" />


**I limited all the number edits max characters so the user can only enter less than 1 billion in the edits.**


### 1. Check either limit length or limit size checkboxes.
<img width="297" height="67" alt="image" src="https://github.com/user-attachments/assets/89226e27-0801-40bb-9112-8b1add6c6275" />

### 2. After checking, the corresponding edit does not receive focus. imo, it should. 


Fixed/implemented these in my commit. 

These were the only issues I could find when I tested wcap  :)